### PR TITLE
fix: resolve 404 issue after logout redirect in Header component

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -12,7 +12,7 @@ const Header: React.FC = () => {
 
   const handleLogout = () => {
     logout();
-    navigate('/login');
+    navigate('/');
   };
 
   // Generate greeting based on role and name


### PR DESCRIPTION
after clicking logout, it was redirecting to /login but actually it doesn't exist for now, since login end point is at ''/" end point